### PR TITLE
Refactored Code and Support for Apache Iceberg Tables Schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 venv/*
 .vscode/*
 *test.py
+.DS_Store

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,1 @@
+# Contains sample projects made on top of EA code base

--- a/src/bin/alterator.py
+++ b/src/bin/alterator.py
@@ -555,6 +555,8 @@ class Alterator:
                     "num_new": len(self.new_tables),
                     "num_errored": len(self.errored_tables),
                     "num_identical": len(self.identical_tables),
+                    "num_non_parquet_tables": len(self.non_parquet_tables),
+                    "num_iceberg_tables": len(self.iceberg_tables)
                 },
             },
             "skipped_tables": self.skipped_tables,

--- a/src/bin/alterator.py
+++ b/src/bin/alterator.py
@@ -1,0 +1,507 @@
+"""Main class for Alterator, Sync and Validator"""
+import re
+import os
+from rules import rule_book as rbook
+from utils import helper as hfunc
+from utils import glue_utils as glue
+from utils import file_utils as futils
+from utils import s3_utils as s3utils
+import logging
+
+
+class Alterator:
+    def __init__(self, paths, path_key, ddl_config_path, ddl_file_prefix, ddl_file_suffix, validate, force):
+        self.paths = paths
+        self.path_key = path_key
+        self.ddl_config_path = ddl_config_path
+        self.ddl_file_prefix = ddl_file_prefix
+        self.ddl_file_suffix = ddl_file_suffix
+        self.config = None
+        self.logger = logging.getLogger("EA.process.alterator")
+        self.table_rgx = r"""TABLE [IF NOT EXISTS]*\s*`(\w+)[\.](\w+)`"""
+        self.column_rgs = r"""`(\w+)`\s+(\w+(\(\d+,\d+\))?),*"""
+        self.validate = validate
+        self.force = force
+        self.hql_paths = []
+        self.skipped_tables = []
+        self.new_tables = []
+        self.success_tables = []
+        self.errored_tables = []
+        self.identical_tables = []
+        self.aws_account_id = hfunc.get_account_id()
+
+
+    def _initialize_paths(self):
+        """
+        Initializes the HQL paths based on the provided paths and configuration.
+
+        If paths are provided, it validates and sets them. If a DDL configuration path is provided,
+        it reads the configuration and appends the paths specified in the configuration.
+
+        Raises:
+            Exception: If the provided configuration file is not valid or the key for path is not available.
+        """
+        if self.paths:
+            futils.check_paths(self.paths)
+            self.hql_paths = self.paths
+        # Checks if the DDL Configuration file path exists or not
+        if self.ddl_config_path:
+            futils.check_paths(self.ddl_config_path)
+            if self.ddl_config_path.endswith(".yaml") and (os.path.isfile(self.ddl_config_path) or self.ddl_config_path.startswith("s3://")):
+                # Read the configuration YAML file
+                self.config = futils.read_yaml(self.ddl_config_path)
+                # Check if the HQL File path key exists.
+                if self.path_key in self.config:
+                    # Check if the path is correct
+                    futils.check_paths(self.config[self.path_key])
+                    self.hql_paths.append(self.config[self.path_key])
+                else:
+                    if not self.paths:
+                        raise Exception(f"Provided key_for_path is not available in {self.ddl_config_path} configuration file")
+            else:
+                raise Exception("Only .yaml configuration files are supported or invalid file path.")
+
+    def _filter_files(self):
+        """
+        Filters the HQL files based on the provided configuration.
+
+        If a configuration is provided, it filters the files based on the table names specified in the configuration.
+        Otherwise, it filters the files based on the HQL paths, DDL file prefix, and DDL file suffix.
+
+        Returns:
+            list: A list of filtered files.
+        """
+        if self.config:
+            return futils.filter_files(
+                self.hql_paths, self.ddl_file_prefix, self.ddl_file_suffix, table_names=self.config["tables"]
+            )
+        else:
+            return futils.filter_files(
+                self.hql_paths, self.ddl_file_prefix, self.ddl_file_suffix
+            )
+
+    def _read_file_content(self, fname):
+        """
+        Reads the content of a file and processes it.
+
+        If the file is located in an S3 bucket (indicated by the "s3://" prefix),
+        it reads the file using the `s3utils.read_s3_file` function. Otherwise, it
+        reads the file from the local filesystem.
+
+        The content of the file is converted to lowercase, stripped of leading and
+        trailing whitespace, and formatted with the `aws_account_id` attribute.
+
+        Args:
+            fname (str): The path to the file. Can be an S3 URI or a local file path.
+
+        Returns:
+            str: The processed content of the file.
+        """
+        if fname.startswith("s3://"):
+            file_content = s3utils.read_s3_file(fname)
+            return file_content.lower().strip().format(aws_account_id=self.aws_account_id)
+        else:
+            with open(fname, "r", encoding="utf-8") as filestream:
+                return filestream.read().lower().strip().format(aws_account_id=self.aws_account_id)
+
+    def _extract_table_name(self, data, fname):
+        """
+        Extracts the table name from the provided data using a regular expression.
+
+        Args:
+            data (str): The string data containing the DDL statement.
+            fname (str): The filename from which the data was read, used for logging purposes.
+
+        Returns:
+            tuple: A tuple containing the extracted table name in the format "db.table" and a boolean flag.
+                   The boolean flag is False if the table name was successfully extracted, and True if there was an error.
+        """
+        table_match = re.search(self.table_rgx, data, flags=re.IGNORECASE)
+        if table_match:
+            db, table = table_match.groups()
+            return f"{db}.{table}", False
+        else:
+            self.logger.error("==> Please validate the DDL format for %s", fname)
+            return "", True
+
+    def _validate_create_statement(self, data, table_name, fname):
+        """
+        Validates if the provided HQL statement is a CREATE statement.
+
+        Args:
+            data (str): The HQL statement to validate.
+            table_name (str): The name of the table associated with the HQL statement.
+            fname (str): The filename where the HQL statement is located.
+
+        Returns:
+            tuple: A tuple containing a dictionary with error details and a boolean indicating validation failure.
+                   If the statement is not a CREATE statement, the dictionary contains:
+                   - "table_name": The name of the table.
+                   - "filename": The filename where the HQL statement is located.
+                   - "reason": The reason for validation failure ("NonCreateSQL").
+                   The boolean is True if validation fails, otherwise False.
+        """
+        if not data.startswith("create"):
+            self.logger.error("==> HQL provided for %s is not a create statement.", table_name)
+            return {
+                "table_name": table_name,
+                "filename": fname,
+                "reason": "NonCreateSQL",
+            }, True
+        return None, False
+
+    def _run_initial_validation(self, data, table_name):
+        """
+        Runs initial validation checks on the provided data.
+
+        Args:
+            data (Any): The data to be validated.
+            table_name (str): The name of the table associated with the data.
+
+        Returns:
+            tuple: A tuple containing:
+                - dict or None: A dictionary with error details if validation fails, otherwise None.
+                - bool: True if validation fails, otherwise False.
+        """
+        self.logger.info("*** Running initial validation.***")
+        validation_type, validation_results = hfunc.intial_checks(data)
+        if validation_results:
+            self.logger.info("=> Initial validations are successful for %s.", table_name)
+            return None, False
+        else:
+            self.logger.error("==> Initial validation: %s failed for provided HQL %s.", validation_type, table_name)
+            return {
+                "table_name": table_name,
+                "reason": "ValidationError",
+                "type": validation_type,
+                "from": "HQL",
+            }, True
+
+    def _fetch_table_details(self, db, table):
+        """
+        Fetches the details of a specified table from the AWS Glue Catalog.
+
+        Args:
+            db (str): The name of the database.
+            table (str): The name of the table.
+
+        Returns:
+            tuple: A tuple containing:
+                - dict or None: The details of the table if found, otherwise None.
+                - bool: True if there was an error fetching the table details, otherwise False.
+        """
+        tbl_details = glue.get_table_details(db, table)
+        if isinstance(tbl_details, dict) and "Error" in tbl_details:
+            return None, True
+        return tbl_details, False
+
+    def _validate_catalog(self, tbl_details, table_name):
+        """
+        Runs initial validation on the schema present in AWS Glue Catalog
+
+        Args:
+            tbl_details (dict): The details of the table to validate.
+            table_name (str): The name of the table.
+
+        Returns:
+            tuple: A tuple containing:
+                - dict or None: If validation fails, a dictionary with details of the failure. Otherwise, None.
+                - bool: True if validation fails, False otherwise.
+        """
+        catalog_validation_type, catalog_validation = hfunc.intial_checks(tbl_details)
+        if catalog_validation:
+            self.logger.info("=> Initial validation for catalog passed.")
+            return None, False
+        else:
+            self.logger.error("==> Initial validation for catalog failed.")
+            return {
+                "table_name": table_name,
+                "reason": "ValidationError",
+                "type": catalog_validation_type,
+                "from": "CATALOG",
+            }, True
+
+    def _validate_partition_columns(self, data, partition_keys, table_name):
+        """
+        Validates the partition columns of the given hql against the partition keys
+        present in AWS Glue Catalog.
+
+        Args:
+            data (DataFrame): The data to be validated.
+            partition_keys (list): The list of partition keys to validate against.
+            table_name (str): The name of the table being validated.
+
+        Returns:
+            tuple: A tuple containing:
+                - dict or None: If validation fails, returns a dictionary with the table name and reason for failure.
+                                If validation passes, returns None.
+                - bool: A boolean indicating whether the validation failed (True) or passed (False).
+        """
+        partition_validation = rbook.partition_col_check(data, partition_keys)
+        if partition_validation:
+            self.logger.info("=> Partition Validation passed for %s.", table_name)
+            return None, False
+        else:
+            self.logger.error("==> Partition Validation failed for %s.", table_name)
+            return {
+                "table_name": table_name,
+                "reason": "PartitionValidationError",
+            }, True
+
+    def _compare_schemas(self, data, columns, partition_keys):
+        """
+        Compare the schemas between the provided data and catalog columns.
+        HQL vs Glue Catalog Schema
+
+        Args:
+            data (str): The data containing the schema information.
+            columns (list): A list of column dictionaries from the catalog.
+            partition_keys (list): A list of partition key dictionaries from the catalog.
+
+        Returns:
+            tuple: A tuple containing:
+                - added_cols_dlist (list): A list of dictionaries representing columns added in the schema.
+                - del_cols_dlist (list): A list of dictionaries representing columns deleted from the schema.
+                - merged_df (DataFrame): A DataFrame representing the merged schema comparison.
+        """
+        hql_cols = re.findall(self.column_rgs, data, flags=re.IGNORECASE)
+        hql_col_dlist = [{"Name": col[0], "Type": col[1]} for col in hql_cols]
+        catalog_col_list = columns + partition_keys
+        added_cols_dlist, del_cols_dlist, merged_df = hfunc.compare_schema(hql_col_dlist, catalog_col_list)
+        return added_cols_dlist, del_cols_dlist, merged_df
+
+    def _update_table_schema(self, db, table, tbl_details, added_cols_dlist, del_cols_dlist, table_name):
+        """
+        Updates the schema of a specified table in the database.
+
+        Parameters:
+        db (str): The database name.
+        table (str): The table name.
+        tbl_details (dict): The details of the table schema.
+        added_cols_dlist (list): List of columns to be added.
+        del_cols_dlist (list): List of columns to be deleted.
+        table_name (str): The name of the table to be updated.
+
+        Returns:
+        tuple: A tuple containing a dictionary with the update details and a boolean indicating success.
+        The dictionary contains:
+            - table_name (str): The name of the table.
+            - previous_version (str): The previous version of the table schema.
+            - current_version (str): The current version of the table schema.
+            - details (dict): A dictionary with keys 'add' and 'delete' listing the columns added and deleted respectively.
+        The boolean indicates whether the update was successful.
+        """
+        if not (added_cols_dlist or del_cols_dlist):
+            self.logger.info("=> Update is not required for `%s`", table_name)
+            return None, True
+
+        if self.validate:
+            self.logger.info("=> Table will be updated with the identified changes.")
+            current_ver = glue.get_latest_table_version(db, table)
+            return {
+                "table_name": table_name,
+                "previous_version": current_ver,
+                "current_version": current_ver,
+                "details": {
+                    "add": added_cols_dlist,
+                    "delete": del_cols_dlist,
+                },
+            }, True
+
+        previous_ver = glue.get_latest_table_version(db, table)
+        status, _, error = glue.update_table_schema(
+            table=tbl_details,
+            new_cols=added_cols_dlist,
+            del_cols=del_cols_dlist,
+        )
+        updated_ver = glue.get_latest_table_version(db, table)
+        success_response = {
+            "table_name": table_name,
+            "previous_version": previous_ver,
+            "current_version": updated_ver,
+            "details": {
+                "add": added_cols_dlist,
+                "delete": del_cols_dlist,
+            },
+        }
+        if not status:
+            self.logger.error("==> Exception occurred while updating table schema for %s.", table_name)
+            self.logger.error("Exception details: %s - %s", error['Code'], error['Message'])
+            return success_response, False
+
+        return success_response, True
+
+    def alter_schema(self):
+        """
+        Alters the schema of tables based on the provided configurations and validations.
+
+        This method performs the following steps:
+        1. Initializes paths.
+        2. Filters the list of files to process.
+        3. Iterates over each file and processes it:
+            - Reads the file content.
+            - Extracts the table name.
+            - Validates the CREATE statement.
+            - Runs initial validation on the data.
+            - Fetches table details from the Glue Catalog.
+            - Validates the catalog information.
+            - Validates partition columns.
+            - Compares schemas between the file and the Glue Catalog.
+            - Validates data type compatibility.
+            - Updates the table schema if necessary.
+
+        The method handles various scenarios such as:
+        - Skipping tables if the table name cannot be extracted.
+        - Skipping tables if the CREATE statement is invalid.
+        - Identifies new tables if they do not exist in the Glue Catalog.
+        - Skipping schema updates if there are incompatible data type changes (unless forced).
+        - Updates table schema if schema updates present in HQL file are valid.
+        - Logging and appending tables to respective lists based on the outcome (success, identical, skipped, errored).
+
+        Exceptions:
+            Logs any exceptions that occur during the process.
+
+        Returns:
+            None
+        """
+        self._initialize_paths()
+        final_file_list = self._filter_files()
+        try:
+            for fname in final_file_list:
+                self.logger.info("###### Process started for %s ######", fname)
+                data = self._read_file_content(fname)
+                if not data:
+                    continue
+                table_name, skip = self._extract_table_name(data, fname)
+                if skip:
+                    self.skipped_tables.append(
+                        {
+                            "table_name": "",
+                            "filename": fname,
+                            "reason": "TableNameNotExtracted",
+                        }
+                    )
+                    continue
+
+                error, skip = self._validate_create_statement(data, table_name, fname)
+                if skip:
+                    self.skipped_tables.append(error)
+                    continue
+
+                error, skip = self._run_initial_validation(data, table_name)
+                if skip:
+                    self.skipped_tables.append(error)
+                    continue
+
+                db, table = table_name.split('.')
+                tbl_details, error = self._fetch_table_details(db, table)
+                if error:
+                    self.new_tables.append(table_name)
+                    continue
+
+                error, skip = self._validate_catalog(tbl_details, table_name)
+                if skip:
+                    self.skipped_tables.append(error)
+                    continue
+
+                partition_keys = tbl_details["Table"]["PartitionKeys"]
+                error, skip = self._validate_partition_columns(data, partition_keys, table_name)
+                if skip:
+                    self.skipped_tables.append(error)
+                    continue
+
+                # Schema comparison HQL vs GlueCatalog
+                columns = tbl_details["Table"]["StorageDescriptor"]["Columns"]
+                added_cols_dlist, del_cols_dlist, merged_df = self._compare_schemas(data, columns, partition_keys)
+                # Data type for column changed
+                if not merged_df.empty:
+                    self.logger.info("****Validating data type compatibility for %s****", table_name)
+                    response, compatible, incompatible = rbook.check_dtype_compatibility(merged_df)
+                    # Incompatible data type change detected
+                    if not response:
+                        if self.force:
+                            self.logger.warning("FORCE flag is enabled. Table will be updated with incompatible data type changes.")
+                            new_dtype_cols = merged_df[["Name", "Type_new"]].rename(columns={"Type_new": "Type"}).to_dict("records")
+                            old_dtype_cols = merged_df[["Name", "Type_old"]].rename(columns={"Type_old": "Type"}).to_dict("records")
+                            added_cols_dlist += new_dtype_cols
+                            del_cols_dlist += old_dtype_cols
+                        else:
+                            self.logger.info("==> Skipping schema update for %s", table_name)
+                            compatible_cols = compatible[["Name", "Type_old", "Type_new"]].rename(columns={"Type_old": "Type", "Type_new": "updated_type"}).to_dict("records")
+                            incompatible_cols = incompatible[["Name", "Type_old", "Type_new"]].rename(columns={"Type_old": "Type", "Type_new": "updated_type"}).to_dict("records")
+                            self.skipped_tables.append({
+                                "table_name": table_name,
+                                "reason": "IncompatibleDataTypeError",
+                                "details": {
+                                    "compatible": compatible_cols,
+                                    "incompatible": incompatible_cols,
+                                    "add": added_cols_dlist,
+                                    "delete": del_cols_dlist,
+                                },
+                            })
+                            continue
+                    else:
+                        if not compatible.empty:
+                            self.logger.info("Getting compatible datatype columns.")
+                            new_dtype_cols = compatible[["Name", "Type_new"]].rename(columns={"Type_new": "Type"}).to_dict("records")
+                            old_dtype_cols = compatible[["Name", "Type_old"]].rename(columns={"Type_old": "Type"}).to_dict("records")
+                            added_cols_dlist += new_dtype_cols
+                            del_cols_dlist += old_dtype_cols
+
+                success_response, status = self._update_table_schema(db, table, tbl_details, added_cols_dlist, del_cols_dlist, table_name)
+                if status:
+                    if success_response:
+                        self.success_tables.append(success_response)
+                    else:
+                        self.identical_tables.append(table_name)
+                else:
+                    self.errored_tables.append(table_name)
+
+        except Exception as e:
+            self.logger.error("An error occurred: %s", e)
+
+    def get_results(self):
+        """
+        Generates a dictionary containing the results of the table analysis.
+
+        Returns:
+            dict: A dictionary with the following structure:
+                - "ResponseMetadata" (dict): Metadata about the response.
+                    - "validation" (str): The validation status.
+                    - "force" (str): The force status.
+                    - "stats" (dict): Statistics about the table analysis.
+                        - "num_tables_analyzed" (int): Total number of tables analyzed.
+                        - "num_updates" (int): Number of tables successfully updated.
+                        - "num_skipped" (int): Number of tables skipped.
+                        - "num_new" (int): Number of new tables.
+                        - "num_errored" (int): Number of tables that encountered errors.
+                        - "num_identical" (int): Number of tables that are identical.
+                - "skipped_tables" (list): List of skipped tables.
+                - "new_tables" (list): List of new tables.
+                - "success_tables" (list): List of successfully updated tables.
+                - "errored_tables" (list): List of tables that encountered errors.
+                - "identical_tables" (list): List of identical tables.
+        """
+        return {
+            "ResponseMetadata": {
+                "validation": str(self.validate),
+                "force": str(self.force),
+                "stats": {
+                    "num_tables_analyzed": len(self.skipped_tables)
+                    + len(self.new_tables)
+                    + len(self.errored_tables)
+                    + len(self.success_tables)
+                    + len(self.identical_tables),
+                    "num_updates": len(self.success_tables),
+                    "num_skipped": len(self.skipped_tables),
+                    "num_new": len(self.new_tables),
+                    "num_errored": len(self.errored_tables),
+                    "num_identical": len(self.identical_tables),
+                },
+            },
+            "skipped_tables": self.skipped_tables,
+            "new_tables": self.new_tables,
+            "success_tables": self.success_tables,
+            "errored_tables": self.errored_tables,
+            "identical_tables": self.identical_tables,
+        }

--- a/src/bin/alterator.py
+++ b/src/bin/alterator.py
@@ -1,4 +1,4 @@
-"""Main class for Alterator, Sync and Validator"""
+"""Main class for Alterator"""
 import re
 import os
 from rules import rule_book as rbook
@@ -10,6 +10,44 @@ import logging
 
 
 class Alterator:
+    """
+    Alterator class for managing and altering table schemas based on provided configurations and validations.
+
+    Attributes:
+        paths (list): List of paths to HQL files.
+        path_key (str): Key for the HQL file path in the configuration.
+        ddl_config_path (str): Path to the DDL configuration file.
+        ddl_file_prefix (str): Prefix for DDL files.
+        ddl_file_suffix (str): Suffix for DDL files.
+        validate (bool): Flag to enable validation mode.
+        force (bool): Flag to force schema updates despite incompatible changes.
+        config (dict): Configuration dictionary read from the DDL configuration file.
+        logger (Logger): Logger instance for logging messages.
+        table_rgx (str): Regular expression for extracting table names from HQL files.
+        column_rgs (str): Regular expression for extracting column definitions from HQL files.
+        hql_paths (list): List of validated HQL file paths.
+        skipped_tables (list): List of tables that were skipped during processing.
+        new_tables (list): List of new tables identified during processing.
+        success_tables (list): List of tables that were successfully updated.
+        errored_tables (list): List of tables that encountered errors during processing.
+        identical_tables (list): List of tables that were found to be identical.
+        aws_account_id (str): AWS account ID.
+
+    Methods:
+        _initialize_paths(): Initializes the HQL paths based on the provided paths and configuration.
+        _filter_files(): Filters the HQL files based on the provided configuration.
+        _read_file_content(fname): Reads the content of a file and processes it.
+        _extract_table_name(data, fname): Extracts the table name from the provided data using a regular expression.
+        _validate_create_statement(data, table_name, fname): Validates if the provided HQL statement is a CREATE statement.
+        _run_initial_validation(data, table_name): Runs initial validation checks on the provided data.
+        _fetch_table_details(db, table): Fetches the details of a specified table from the AWS Glue Catalog.
+        _validate_catalog(tbl_details, table_name): Runs initial validation on the schema present in AWS Glue Catalog.
+        _validate_partition_columns(data, partition_keys, table_name): Validates the partition columns of the given HQL against the partition keys present in AWS Glue Catalog.
+        _compare_schemas(data, columns, partition_keys): Compares the schemas between the provided data and catalog columns.
+        _update_table_schema(db, table, tbl_details, added_cols_dlist, del_cols_dlist, table_name): Updates the schema of a specified table in the database.
+        alter_schema(): Alters the schema of tables based on the provided configurations and validations.
+        get_results(): Generates a dictionary containing the results of the table analysis.
+    """
     def __init__(self, paths, path_key, ddl_config_path, ddl_file_prefix, ddl_file_suffix, validate, force):
         self.paths = paths
         self.path_key = path_key

--- a/src/easy_alterator.py
+++ b/src/easy_alterator.py
@@ -1,7 +1,8 @@
 """Entry point for Easy Alterator functionality."""
 import argparse
 import sys
-from bin.process import sync_tables, alterator
+from bin.process import sync_tables
+from bin.alterator import Alterator
 import logging
 
 
@@ -134,15 +135,17 @@ if __name__ == "__main__":
 
     try:
         logger.info("Alterator process called.")
-        response = alterator(
-            paths=paths,
-            ddl_config_path=ddl_config_path,
-            path_key=path_key,
-            ddl_file_prefix=ddl_file_prefix,
-            ddl_file_suffix=ddl_file_suffix,
-            validate=validate,
-            force=force
+        alterator_process = Alterator(
+            paths,
+            path_key,
+            ddl_config_path,
+            ddl_file_prefix,
+            ddl_file_suffix,
+            validate,
+            force
         )
+        alterator_process.alter_schema()
+        response = alterator_process.get_results()
         logger.info("Alterator process completed successfully.")
         print(response)
     except Exception as ex:

--- a/src/handler/iceberg_schema_handler.py
+++ b/src/handler/iceberg_schema_handler.py
@@ -1,75 +1,126 @@
 """Main Class for getting the Iceberg Table Schema Changes."""
+
 from typing import Dict, Any, Tuple, List, Union
 import json
 import logging
+import re
+from operator import itemgetter
 import pandas as pd
 from utils.s3_utils import read_s3_file
 from utils.glue_utils import get_table_details
 
 
 class IcebergSchemaHandler:
-    """Class to get the schema changes for Iceberg Tables."""
-    def __init__(self, table: str, hql_str: str, iceberg_catalog: str="spark_catalog",
-                requires_migration: bool = False, catalog: str="glue"):
+    """Class to get the schema changes for Iceberg Tables.
+
+    This class handles comparing schema changes between an existing Iceberg table and a new schema
+    defined in HQL. It can also handle schema migration from non-Iceberg to Iceberg tables.
+
+    Args:
+        table (str): The fully qualified table name in format 'database.table'
+        hql_str (str): The HQL string containing the new table schema definition
+        iceberg_catalog (str, optional): The Iceberg catalog name. Defaults to "spark_catalog"
+        requires_migration (bool, optional): Whether table needs migration from non-Iceberg. Defaults to False
+        catalog (str, optional): The catalog type. Defaults to "glue"
+
+    Attributes:
+        table (str): The fully qualified table name
+        _db (str): The database name parsed from table
+        _table (str): The table name parsed from table
+        hql (str): The HQL string containing schema
+        ic_catalog (str): The Iceberg catalog name
+        catalog (str): The catalog type
+        migration (bool): Whether table requires migration
+        logger (Logger): Logger instance
+        col_rgx (str): Regex pattern for matching column definitions
+        partition_col_rgx (str): Regex pattern for matching partition columns
+        tblprop_rgx (str): Regex pattern for matching table properties
+    """
+
+    def __init__(
+        self,
+        table: str,
+        hql_str: str,
+        iceberg_catalog: str = "spark_catalog",
+        requires_migration: bool = False,
+        catalog: str = "glue",
+    ):
         self.table = table
         self._db, self._table = table.split(".")
         self.hql = hql_str
         self.ic_catalog = iceberg_catalog
         self.catalog = catalog
         self.migration = requires_migration
-        self.logger = logging.getLogger('EA.handler.iceberg_handler')
-        self.col_rgx = r"""(--\s*[^\n`]+)?\s*`([\w-]+)`\s+(\w+((\(\d+,\d+\))|(\(\d+\)))?),*"""
+        self.logger = logging.getLogger("EA.handler.iceberg_handler")
+        self.col_rgx = (
+            r"""(--\s*[^\n`]+)?\s*`([\w-]+)`\s+(\w+((\(\d+,\d+\))|(\(\d+\)))?),*"""
+        )
         self.partition_col_rgx = r"""PARTITIONED BY \(\s*((?:(?:--[^\n]*)?\s*`[^`]+`\s*(?:,|\n|\r\n)?\s*)+)\)"""
-        self.tblprop_rgx = r"""TBLPROPERTIES\s*\(\s*((?:'[\w.-]+'='[\w.-]+'\s*,?\s*)+)\)"""
+        self.tblprop_rgx = (
+            r"""TBLPROPERTIES\s*\(\s*((?:'[\w.-]+'='[\w.-]+'\s*,?\s*)+)\)"""
+        )
 
-
-    #TODO: Fetch columns, partition details, TBLPROPERTIES,  with sequence from HQL file
+    # TODO: Fetch columns, partition details, TBLPROPERTIES,  with sequence from HQL file
     def _get_schema_details_hql(self) -> Tuple[List, List, Dict]:
-        """Fetch Column, partitions and table properties 
-            detail from HQL string using REGEX."""
+        """Fetch Column, partitions and table properties
+        detail from HQL string using REGEX."""
+
         column_matches = re.findall(self.col_rgx, self.hql, flags=re.IGNORECASE)
-        # TODO: Add commented here to identify delete columns
+        # Add commented here to identify delete columns
         column_details = [
-            {"id": id, "name": column[1], "type": column[2],
-            "commented": True if '--' in column[0] else False} 
+            {
+                "id": id,
+                "name": column[1],
+                "type": column[2],
+                "commented": True if "--" in column[0] else False,
+            }
             for id, column in enumerate(column_matches, start=1)
-            ]
+        ]
+
         partition_matches = re.search(self.partition_col_rgx, self.hql, re.DOTALL)
         if partition_matches:
             columns_string = partition_matches.group(1)
-            partition_columns = re.findall(r'(--[^\n`]+)?\s*`([^`]+)`', columns_string, re.DOTALL)
+            partition_columns = re.findall(
+                r"(--[^\n`]+)?\s*`([^`]+)`", columns_string, re.DOTALL
+            )
             partition_details = [
-                {"field-id": id, "name": col_tup[1], 
-                "commented": bool(col_tup[0])} 
+                {"field-id": id, "name": col_tup[1], "commented": bool(col_tup[0])}
                 for id, col_tup in enumerate(partition_columns, start=1000)
-                ]
+            ]
             self.logger.debug("HQL Partition Details %s", partition_details)
         else:
-            self.logger.info("No partition columns present in HQL for table %s", self.table)
+            self.logger.info(
+                "No partition columns present in HQL for table %s", self.table
+            )
             partition_details = []
+
         tblprop_matches = re.search(self.tblprop_rgx, self.hql, re.DOTALL)
         if tblprop_matches:
             properties_string = tblprop_matches.group(1)
             tblprops = re.findall(r"'([\w.-]+)'='([\w.-]+)'", properties_string)
-            tblprop_details = dict(tblprop_details)
+            tblprop_details = dict(tblprops)
         else:
             self.logger.info("No TBLPROPERTIES present in HQL for table %s", self.table)
             tblprop_details = []
         return column_details, partition_details, tblprop_details
 
-    #TODO: Get metadata JSON locaiton from Glue Catalog -- if migration=False
+    # Get metadata JSON locaiton from Glue Catalog -- if migration=False
     def _get_metadata_location(self, tbl_dict: Dict[str, Any]) -> str:
-        if 'metadata_location' in tbl_dict.get("Parameters", {}):
+        if "metadata_location" in tbl_dict.get("Parameters", {}):
             return tbl_dict["Parameters"]["metadata_location"]
         else:
             raise Exception(f"{self.table} is not an ICEBERG table. Please check.")
 
-    #TODO: Get Schema Details: migration=False from JSON, migration=True from catalog
-    def _get_schema_details_metadata(self, metadata_json_path: str) -> Tuple[List, List, Dict[str, str]]:
+    # Get Schema Details: migration=False from JSON, migration=True from catalog
+    def _get_schema_details_metadata(
+        self, metadata_json_path: str
+    ) -> Tuple[List, List, Dict[str, str]]:
         metadata_str = read_s3_file(metadata_json_path)
         metadata = json.loads(metadata_str)
         column_details = metadata["schemas"][metadata["current-schema-id"]]["fields"]
-        partition_details = metadata["partition-specs"][metadata["default-spec-id"]]["fields"]
+        partition_details = metadata["partition-specs"][metadata["default-spec-id"]][
+            "fields"
+        ]
         tblprop_details = metadata["properties"]
         # Removing owner properties as this is not an actual iceberg property
         tblprop_details.pop("owner", None)
@@ -77,51 +128,165 @@ class IcebergSchemaHandler:
 
     def _get_schema_details(self, tbl_dict: Dict[str, Any]) -> Tuple[List, List, Dict]:
         """Get Table Schema details from Glue Catalog. Should only be called
-            when migration is True, i.e. Glue Catalog still has this table as Parquet
-            and will be migrated to ICEBERG."""
-        columns = tbl_dict['StorageDescriptor']['Columns']
-        partition_cols = tbl_dict['PartitionKeys']
+        when migration is True, i.e. Glue Catalog still has this table as Parquet
+        and will be migrated to ICEBERG."""
+        columns = tbl_dict["StorageDescriptor"]["Columns"]
+        partition_cols = tbl_dict["PartitionKeys"]
         all_columns: Dict[str, str] = columns + partition_cols
         if all_columns:
             # id column added to match the spec same as ICEBERG table.
-            column_details = [{"id": i, **d} for i, d in enumerate(all_columns, start=1)]
+            column_details = [
+                {"id": i, **d} for i, d in enumerate(all_columns, start=1)
+            ]
             # only name and field-id is requried from this.
-            partition_details = [{"field-id": i, **d} for i, d in enumerate(partition_cols, start=1000)]
+            partition_details = [
+                {"field-id": i, **d} for i, d in enumerate(partition_cols, start=1000)
+            ]
             # TBLPROPERTIES dict doesn't matter as table is parquet currently.
             return column_details, partition_details, {}
         else:
             raise Exception("No columns extracted from Glue Catalog.")
 
-    def _compare_schemas(self, catalog_details: Dict[str, Any], hql_details: Dict[str, Any]):
-        self.logger.info("Catalog details received for schema comparison: \n %s", catalog_details)
-        self.logger.info("HQL details received for schema comparison: \n %s", hql_details)
+    def _compare_schemas(
+        self, catalog_details: Dict[str, Any], hql_details: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        self.logger.info(
+            "Catalog details received for schema comparison: \n %s", catalog_details
+        )
+        self.logger.info(
+            "HQL details received for schema comparison: \n %s", hql_details
+        )
+        comparison_results = {"table": f"{self.ic_catalog}.{self.table}"}
 
         # Comparing Columns
         if catalog_details.get("columns") and hql_details.get("columns"):
-            catalog_df = pd.DataFrame.from_records(catalog_details.get("columns"))
+            catalog_df = pd.DataFrame(catalog_details.get("columns"))
             if self.migration:
                 catalog_df = catalog_df.rename(columns={"Name": "name", "Type": "type"})
-            # Filter out all the records that has commented as true -- deleted columns
-            filtered_cols = list(filter(lambda x: not x['commented'], hql_details.get("columns")))
-            hql_df = pd.DataFrame.from_records(filtered_cols)
-            # TODO: comparing both the schemas here.
 
+            # Filter out all the records that has commented as true -- deleted columns
+            filtered_cols = list(
+                filter(lambda x: not x["commented"], hql_details.get("columns"))
+            )
+            hql_df = pd.DataFrame(filtered_cols)
+
+            # Comparing both the schemas here.
+            merged_df = pd.merge(
+                catalog_df, hql_df, on=["id"], how="outer", suffixes=["_old", "_new"]
+            )
+
+            new_cols = (
+                merged_df.loc[
+                    lambda df: (df["name_old"].isna()) & (df["type_old"].isna()),
+                    ["id", "name_new", "type_new"],
+                ]
+                .rename(columns={"name_new": "name", "type_new": "type"})
+                .to_dict("records")
+            )
+
+            deleted_cols = [
+                row["name_old"]
+                for row in merged_df.loc[
+                    lambda df: (df["name_new"].isna()) & (df["type_new"].isna()),
+                    ["name_old"],
+                ].to_dict("records")
+            ]
+
+            renamed_cols = (
+                merged_df.loc[
+                    lambda df: (df["name_old"] != df["name_new"])
+                    & (df["type_old"] == df["type_new"]),
+                    ["name_old", "name_new"],
+                ]
+                .rename(columns={"name_old": "old_name", "name_new": "new_name"})
+                .to_dict("records")
+            )
+
+            updated_cols = (
+                merged_df.loc[
+                    lambda df: (df["name_old"] == df["name_new"])
+                    & (df["type_old"] != df["type_new"]),
+                    ["name_old", "type_old", "type_new"],
+                ]
+                .rename(
+                    columns={
+                        "name_old": "name",
+                        "type_old": "old_type",
+                        "type_new": "new_type",
+                    }
+                )
+                .to_dict("records")
+            )
+
+            comparison_results["columns"] = {
+                "new": sorted(new_cols, key=itemgetter("id")),
+                "dropped": deleted_cols,
+                "renamed": renamed_cols,
+                "updated": updated_cols,
+            }
         else:
             raise ValueError("One of the catalog or hql table details are not fetched.")
 
         # Comparing Partition Columns
-        if catalog_details.get("partition_columns") and hql_details.get("partition_columns"):
-            catalog_part_df = pd.DataFrame.from_records(catalog_details.get("partition_columns"))
+        catalog_part_columns = catalog_details.get("partition_columns")
+        hql_part_columns = hql_details.get("partition_columns")
+        if catalog_part_columns and hql_part_columns:
+            catalog_part_df = pd.DataFrame(catalog_part_columns)
             if self.migration:
                 catalog_part_df = catalog_part_df.rename(columns={"Name": "name"})
             catalog_part_df = catalog_part_df[["field-id", "name"]]
-            #TODO: Filter the commented=True columns
-            filtered_part_cols = list(filter(lambda x: not x['commented'], hql_details.get("partition_columns")))
-            hql_part_df = pd.DataFrame.from_records(filtered_part_cols)[["field-id", "name"]]
-            # TODO: compare both the schemas here.
+            # Filter the commented=True columns
+            filtered_part_cols = list(
+                filter(lambda x: not x["commented"], hql_part_columns)
+            )
+            hql_part_df = pd.DataFrame(filtered_part_cols)[["field-id", "name"]]
+            # Compare partition columns here.
+            merged_part_df = pd.merge(
+                catalog_part_df,
+                hql_part_df,
+                on=["field-id"],
+                how="outer",
+                suffixes=["_old", "_new"],
+            )
+            # new partitions cols
+            new_part_cols = (
+                merged_part_df.loc[
+                    lambda df: (df["name_old"].isna()), ["field-id", "name_new"]
+                ]
+                .rename(columns={"name_new": "name"})
+                .to_dict("records")
+            )
+
+            # dropped partition cols
+            dropped_part_cols = [
+                row["name_old"]
+                for row in merged_part_df.loc[
+                    lambda df: (df["name_new"].isna()), ["name_old"]
+                ].to_dict("records")
+            ]
+
+            # replaced partition cols
+            replaced_part_cols = (
+                merged_part_df.loc[
+                    lambda df: (df["name_old"] != df["name_new"])
+                    & (df["name_old"].notna())
+                    & (df["name_new"].notna()),
+                    ["name_old", "name_new"],
+                ]
+                .rename(columns={"name_old": "old_name", "name_new": "new_name"})
+                .to_dict("records")
+            )
         else:
-            # TODO: Update here
-            print("set partition changes based on which side values are present")
+            replaced_part_cols = []
+            dropped_part_cols = catalog_part_columns
+            new_part_cols = hql_part_columns
+
+        # Updating comparison_results dict with Partition cols
+        comparison_results["partition_columns"] = {
+            "new": sorted(new_part_cols, key=itemgetter("field-id")),
+            "dropped": dropped_part_cols,
+            "replaced": replaced_part_cols,
+        }
 
         # TBLPROP comparison is only possible when both sides are ICEBREG.
         catalog_tblprops = catalog_details.get("table_properties")
@@ -130,49 +295,128 @@ class IcebergSchemaHandler:
             if catalog_tblprops and hql_tblprops:
                 self.logger.debug("Both CATALOG and HQL Props are present.")
                 # Checks keys that are removed
-                removed_props: List[str] = list(set(catalog_tblprops.keys()) - set(hql_tblprops.keys()))
+                removed_props: List[str] = list(
+                    set(catalog_tblprops.keys()) - set(hql_tblprops.keys())
+                )
                 # Check for any new key added
                 new_keys = list(set(hql_tblprops.keys()) - set(catalog_tblprops.keys()))
-                new_props: Union[Dict[str, str], dict] = {new_prop: hql_tblprops[new_prop] for new_prop in new_keys} if new_keys else {}
+                new_props: Union[Dict[str, str], dict] = (
+                    {new_prop: hql_tblprops[new_prop] for new_prop in new_keys}
+                    if new_keys
+                    else {}
+                )
                 # Check for updated columns
-                common_keys = list(set(catalog_tblprops.keys()).intersection(set(hql_tblprops.keys())))
-                updated_props: Union[Dict[str, str], dict] = {ckey: hql_tblprops[ckey] for ckey in common_keys} if common_keys else {}
+                common_keys = list(
+                    set(catalog_tblprops.keys()).intersection(set(hql_tblprops.keys()))
+                )
+                updated_props: Union[Dict[str, str], dict] = (
+                    {ckey: hql_tblprops[ckey] for ckey in common_keys}
+                    if common_keys
+                    else {}
+                )
             else:
                 updated_props = {}
-                removed_props = list(catalog_tblprops.keys()) if catalog_tblprops else []
+                removed_props = (
+                    list(catalog_tblprops.keys()) if catalog_tblprops else []
+                )
                 new_props = hql_tblprops if hql_tblprops else {}
         else:
             new_props = hql_tblprops if hql_tblprops else {}
             removed_props = []
             updated_props = {}
 
+        # Updating comparison_results dict with TBLPROPERTIES
+        comparison_results["tblprops"] = {
+            "new": new_props,
+            "removed": removed_props,
+            "updated": updated_props,
+        }
+        return comparison_results
 
+    def get_schema_updates(self) -> Dict[str, Any]:
+        """
+        Compares schema details between HQL and catalog (Glue) to identify changes.
 
-    #TODO: Compare Schema -- get the change details.
-    def get_schema_updates(self):
+        Gets schema details from both HQL and catalog source, then compares them to identify:
+        - New, dropped, renamed and updated columns
+        - New, dropped and replaced partition columns
+        - New, removed and updated table properties
+
+        Returns:
+            Dict[str, Any]: Dictionary containing schema comparison results with structure:
+                {
+                    'table': str,  # Table name
+                    'columns': {  # Column changes
+                        'new': List[Dict],  # New columns added
+                        'dropped': List[str],  # Columns removed
+                        'renamed': List[Dict],  # Columns renamed
+                        'updated': List[Dict]  # Columns with type changes
+                    },
+                    'partition_columns': {  # Partition column changes
+                        'new': List[Dict],  # New partition columns
+                        'dropped': List[str],  # Removed partition columns
+                        'replaced': List[Dict]  # Modified partition columns
+                    },
+                    'tblprops': {  # Table property changes
+                        'new': Dict,  # New properties added
+                        'removed': List[str],  # Properties removed
+                        'updated': Dict  # Properties modified
+                    }
+                }
+
+        Raises:
+            ValueError: If catalog type is not supported or schema details cannot be fetched
+        """
         h_columns, h_partition_cols, h_tblprop = self._get_schema_details_hql()
         if self.catalog == "glue":
-            tbl_details = get_table_details(self._db, self._table)['Table']
+            tbl_details = get_table_details(self._db, self._table)["Table"]
             if not self.migration:
                 metadata_path = self._get_metadata_location(tbl_details)
                 # c_ is to identify catalog columns, i.e. table details in catalog right now
-                c_columns, c_partition_cols, c_tblprop = self._get_schema_details_metadata(metadata_path)
+                c_columns, c_partition_cols, c_tblprop = (
+                    self._get_schema_details_metadata(metadata_path)
+                )
             else:
-                c_columns, c_partition_cols, c_tblprop = self._get_schema_details(tbl_details)
+                c_columns, c_partition_cols, c_tblprop = self._get_schema_details(
+                    tbl_details
+                )
         else:
             raise ValueError(f"{self.catalog} is not supported yet.")
 
         hql_details = {
             "columns": h_columns,
             "partition_columns": h_partition_cols,
-            "table_properties": h_tblprop
+            "table_properties": h_tblprop,
         }
 
         catalog_details = {
             "columns": c_columns,
             "partition_columns": c_partition_cols,
-            "table_properties": c_tblprop
+            "table_properties": c_tblprop,
         }
 
-    ## Comparison need to happen twice in case of migration = True
-    # TODO: :thinking: comparison should be done before and after of the comparison ?
+        results = self._compare_schemas(catalog_details, hql_details)
+        self.logger.info("Schema comparison results: \n %s", results)
+
+        # Filter out all the keys that has no data from results nested dict
+        return self.clean_results(results)
+
+    def clean_results(self, result: Union[Dict, List]) -> Dict[str, Any]:
+        """
+        Recursively removes empty values from nested dictionaries and lists.
+
+        Args:
+            result (Union[Dict, List]): Input dictionary or list that may contain empty values
+
+        Returns:
+            Dict[str, Any]: Cleaned dictionary with empty values removed
+
+        Example:
+            Input: {'a': [], 'b': {'c': [], 'd': [1,2]}, 'e': [1,2,3]}
+            Output: {'b': {'d': [1,2]}, 'e': [1,2,3]}
+        """
+        if isinstance(result, dict):
+            return {k: self.clean_results(v) for k, v in result.items() if v}
+        if isinstance(result, list):
+            return [self.clean_results(x) for x in result] if result else None
+        return result

--- a/src/handler/iceberg_schema_handler.py
+++ b/src/handler/iceberg_schema_handler.py
@@ -43,9 +43,9 @@ class IcebergSchemaHandler:
                 "commented": bool(col_tup[0])} 
                 for id, col_tup in enumerate(partition_columns, start=1000)
                 ]
-            logger.debug("HQL Partition Details %s", partition_details)
+            self.logger.debug("HQL Partition Details %s", partition_details)
         else:
-            logger.info("No partition columns present in HQL for table %s", self.table)
+            self.logger.info("No partition columns present in HQL for table %s", self.table)
             partition_details = []
         tblprop_matches = re.search(self.tblprop_rgx, self.hql, re.DOTALL)
         if tblprop_matches:
@@ -53,7 +53,7 @@ class IcebergSchemaHandler:
             tblprops = re.findall(r"'([\w.-]+)'='([\w.-]+)'", properties_string)
             tblprop_details = dict(tblprop_details)
         else:
-            logger.info("No TBLPROPERTIES present in HQL for table %s", self.table)
+            self.logger.info("No TBLPROPERTIES present in HQL for table %s", self.table)
             tblprop_details = []
         return column_details, partition_details, tblprop_details
 
@@ -93,8 +93,8 @@ class IcebergSchemaHandler:
             raise Exception("No columns extracted from Glue Catalog.")
 
     def _compare_schemas(self, catalog_details: Dict[str, Any], hql_details: Dict[str, Any]):
-        logger.info("Catalog details received for schema comparison: \n %s", catalog_details)
-        logger.info("HQL details received for schema comparison: \n %s", hql_details)
+        self.logger.info("Catalog details received for schema comparison: \n %s", catalog_details)
+        self.logger.info("HQL details received for schema comparison: \n %s", hql_details)
 
         # Comparing Columns
         if catalog_details.get("columns") and hql_details.get("columns"):
@@ -128,7 +128,7 @@ class IcebergSchemaHandler:
         hql_tblprops = hql_details.get("table_properties")
         if not self.migration:
             if catalog_tblprops and hql_tblprops:
-                logger.debug("Both CATALOG and HQL Props are present.")
+                self.logger.debug("Both CATALOG and HQL Props are present.")
                 # Checks keys that are removed
                 removed_props: List[str] = list(set(catalog_tblprops.keys()) - set(hql_tblprops.keys()))
                 # Check for any new key added

--- a/src/handler/iceberg_schema_handler.py
+++ b/src/handler/iceberg_schema_handler.py
@@ -1,11 +1,14 @@
 """Main Class for getting the Iceberg Table Schema Changes."""
-from typing import Dict, Any, Tuple, List
+from typing import Dict, Any, Tuple, List, Union
 import json
+import logging
+import pandas as pd
 from utils.s3_utils import read_s3_file
 from utils.glue_utils import get_table_details
-import logging
+
 
 class IcebergSchemaHandler:
+    """Class to get the schema changes for Iceberg Tables."""
     def __init__(self, table: str, hql_str: str, iceberg_catalog: str="spark_catalog",
                 requires_migration: bool = False, catalog: str="glue"):
         self.table = table
@@ -15,14 +18,44 @@ class IcebergSchemaHandler:
         self.catalog = catalog
         self.migration = requires_migration
         self.logger = logging.getLogger('EA.handler.iceberg_handler')
-        self.col_rgx = r"""`(\w+)`\s+(\w+((\(\d+,\d+\))|(\(\d+\)))?),*"""
-        self.partition_col_rgx = r"""PARTITIONED BY \(\s*(`[^`]+`(?:\s*,\s*`[^`]+`)*)\s*\)"""
+        self.col_rgx = r"""(--\s*[^\n`]+)?\s*`([\w-]+)`\s+(\w+((\(\d+,\d+\))|(\(\d+\)))?),*"""
+        self.partition_col_rgx = r"""PARTITIONED BY \(\s*((?:(?:--[^\n]*)?\s*`[^`]+`\s*(?:,|\n|\r\n)?\s*)+)\)"""
         self.tblprop_rgx = r"""TBLPROPERTIES\s*\(\s*((?:'[\w.-]+'='[\w.-]+'\s*,?\s*)+)\)"""
 
 
     #TODO: Fetch columns, partition details, TBLPROPERTIES,  with sequence from HQL file
-    def _get_schema_details_hql(self):
-        print("Fetch all the required details from HQL string using regex.")
+    def _get_schema_details_hql(self) -> Tuple[List, List, Dict]:
+        """Fetch Column, partitions and table properties 
+            detail from HQL string using REGEX."""
+        column_matches = re.findall(self.col_rgx, self.hql, flags=re.IGNORECASE)
+        # TODO: Add commented here to identify delete columns
+        column_details = [
+            {"id": id, "name": column[1], "type": column[2],
+            "commented": True if '--' in column[0] else False} 
+            for id, column in enumerate(column_matches, start=1)
+            ]
+        partition_matches = re.search(self.partition_col_rgx, self.hql, re.DOTALL)
+        if partition_matches:
+            columns_string = partition_matches.group(1)
+            partition_columns = re.findall(r'(--[^\n`]+)?\s*`([^`]+)`', columns_string, re.DOTALL)
+            partition_details = [
+                {"field-id": id, "name": col_tup[1], 
+                "commented": bool(col_tup[0])} 
+                for id, col_tup in enumerate(partition_columns, start=1000)
+                ]
+            logger.debug("HQL Partition Details %s", partition_details)
+        else:
+            logger.info("No partition columns present in HQL for table %s", self.table)
+            partition_details = []
+        tblprop_matches = re.search(self.tblprop_rgx, self.hql, re.DOTALL)
+        if tblprop_matches:
+            properties_string = tblprop_matches.group(1)
+            tblprops = re.findall(r"'([\w.-]+)'='([\w.-]+)'", properties_string)
+            tblprop_details = dict(tblprop_details)
+        else:
+            logger.info("No TBLPROPERTIES present in HQL for table %s", self.table)
+            tblprop_details = []
+        return column_details, partition_details, tblprop_details
 
     #TODO: Get metadata JSON locaiton from Glue Catalog -- if migration=False
     def _get_metadata_location(self, tbl_dict: Dict[str, Any]) -> str:
@@ -38,6 +71,8 @@ class IcebergSchemaHandler:
         column_details = metadata["schemas"][metadata["current-schema-id"]]["fields"]
         partition_details = metadata["partition-specs"][metadata["default-spec-id"]]["fields"]
         tblprop_details = metadata["properties"]
+        # Removing owner properties as this is not an actual iceberg property
+        tblprop_details.pop("owner", None)
         return column_details, partition_details, tblprop_details
 
     def _get_schema_details(self, tbl_dict: Dict[str, Any]) -> Tuple[List, List, Dict]:
@@ -57,12 +92,65 @@ class IcebergSchemaHandler:
         else:
             raise Exception("No columns extracted from Glue Catalog.")
 
-    def _compare_schemas(self, catalog_details, hql_details):
-        print("Use pandas to get the changes here...")
+    def _compare_schemas(self, catalog_details: Dict[str, Any], hql_details: Dict[str, Any]):
+        logger.info("Catalog details received for schema comparison: \n %s", catalog_details)
+        logger.info("HQL details received for schema comparison: \n %s", hql_details)
+
+        # Comparing Columns
+        if catalog_details.get("columns") and hql_details.get("columns"):
+            catalog_df = pd.DataFrame.from_records(catalog_details.get("columns"))
+            if self.migration:
+                catalog_df = catalog_df.rename(columns={"Name": "name", "Type": "type"})
+            # Filter out all the records that has commented as true -- deleted columns
+            filtered_cols = list(filter(lambda x: not x['commented'], hql_details.get("columns")))
+            hql_df = pd.DataFrame.from_records(filtered_cols)
+            # TODO: comparing both the schemas here.
+
+        else:
+            raise ValueError("One of the catalog or hql table details are not fetched.")
+
+        # Comparing Partition Columns
+        if catalog_details.get("partition_columns") and hql_details.get("partition_columns"):
+            catalog_part_df = pd.DataFrame.from_records(catalog_details.get("partition_columns"))
+            if self.migration:
+                catalog_part_df = catalog_part_df.rename(columns={"Name": "name"})
+            catalog_part_df = catalog_part_df[["field-id", "name"]]
+            #TODO: Filter the commented=True columns
+            filtered_part_cols = list(filter(lambda x: not x['commented'], hql_details.get("partition_columns")))
+            hql_part_df = pd.DataFrame.from_records(filtered_part_cols)[["field-id", "name"]]
+            # TODO: compare both the schemas here.
+        else:
+            # TODO: Update here
+            print("set partition changes based on which side values are present")
+
+        # TBLPROP comparison is only possible when both sides are ICEBREG.
+        catalog_tblprops = catalog_details.get("table_properties")
+        hql_tblprops = hql_details.get("table_properties")
+        if not self.migration:
+            if catalog_tblprops and hql_tblprops:
+                logger.debug("Both CATALOG and HQL Props are present.")
+                # Checks keys that are removed
+                removed_props: List[str] = list(set(catalog_tblprops.keys()) - set(hql_tblprops.keys()))
+                # Check for any new key added
+                new_keys = list(set(hql_tblprops.keys()) - set(catalog_tblprops.keys()))
+                new_props: Union[Dict[str, str], dict] = {new_prop: hql_tblprops[new_prop] for new_prop in new_keys} if new_keys else {}
+                # Check for updated columns
+                common_keys = list(set(catalog_tblprops.keys()).intersection(set(hql_tblprops.keys())))
+                updated_props: Union[Dict[str, str], dict] = {ckey: hql_tblprops[ckey] for ckey in common_keys} if common_keys else {}
+            else:
+                updated_props = {}
+                removed_props = list(catalog_tblprops.keys()) if catalog_tblprops else []
+                new_props = hql_tblprops if hql_tblprops else {}
+        else:
+            new_props = hql_tblprops if hql_tblprops else {}
+            removed_props = []
+            updated_props = {}
+
 
 
     #TODO: Compare Schema -- get the change details.
     def get_schema_updates(self):
+        h_columns, h_partition_cols, h_tblprop = self._get_schema_details_hql()
         if self.catalog == "glue":
             tbl_details = get_table_details(self._db, self._table)['Table']
             if not self.migration:
@@ -71,6 +159,20 @@ class IcebergSchemaHandler:
                 c_columns, c_partition_cols, c_tblprop = self._get_schema_details_metadata(metadata_path)
             else:
                 c_columns, c_partition_cols, c_tblprop = self._get_schema_details(tbl_details)
+        else:
+            raise ValueError(f"{self.catalog} is not supported yet.")
+
+        hql_details = {
+            "columns": h_columns,
+            "partition_columns": h_partition_cols,
+            "table_properties": h_tblprop
+        }
+
+        catalog_details = {
+            "columns": c_columns,
+            "partition_columns": c_partition_cols,
+            "table_properties": c_tblprop
+        }
 
     ## Comparison need to happen twice in case of migration = True
     # TODO: :thinking: comparison should be done before and after of the comparison ?

--- a/src/handler/iceberg_schema_handler.py
+++ b/src/handler/iceberg_schema_handler.py
@@ -1,0 +1,76 @@
+"""Main Class for getting the Iceberg Table Schema Changes."""
+from typing import Dict, Any, Tuple, List
+import json
+from utils.s3_utils import read_s3_file
+from utils.glue_utils import get_table_details
+import logging
+
+class IcebergSchemaHandler:
+    def __init__(self, table: str, hql_str: str, iceberg_catalog: str="spark_catalog",
+                requires_migration: bool = False, catalog: str="glue"):
+        self.table = table
+        self._db, self._table = table.split(".")
+        self.hql = hql_str
+        self.ic_catalog = iceberg_catalog
+        self.catalog = catalog
+        self.migration = requires_migration
+        self.logger = logging.getLogger('EA.handler.iceberg_handler')
+        self.col_rgx = r"""`(\w+)`\s+(\w+((\(\d+,\d+\))|(\(\d+\)))?),*"""
+        self.partition_col_rgx = r"""PARTITIONED BY \(\s*(`[^`]+`(?:\s*,\s*`[^`]+`)*)\s*\)"""
+        self.tblprop_rgx = r"""TBLPROPERTIES\s*\(\s*((?:'[\w.-]+'='[\w.-]+'\s*,?\s*)+)\)"""
+
+
+    #TODO: Fetch columns, partition details, TBLPROPERTIES,  with sequence from HQL file
+    def _get_schema_details_hql(self):
+        print("Fetch all the required details from HQL string using regex.")
+
+    #TODO: Get metadata JSON locaiton from Glue Catalog -- if migration=False
+    def _get_metadata_location(self, tbl_dict: Dict[str, Any]) -> str:
+        if 'metadata_location' in tbl_dict.get("Parameters", {}):
+            return tbl_dict["Parameters"]["metadata_location"]
+        else:
+            raise Exception(f"{self.table} is not an ICEBERG table. Please check.")
+
+    #TODO: Get Schema Details: migration=False from JSON, migration=True from catalog
+    def _get_schema_details_metadata(self, metadata_json_path: str) -> Tuple[List, List, Dict[str, str]]:
+        metadata_str = read_s3_file(metadata_json_path)
+        metadata = json.loads(metadata_str)
+        column_details = metadata["schemas"][metadata["current-schema-id"]]["fields"]
+        partition_details = metadata["partition-specs"][metadata["default-spec-id"]]["fields"]
+        tblprop_details = metadata["properties"]
+        return column_details, partition_details, tblprop_details
+
+    def _get_schema_details(self, tbl_dict: Dict[str, Any]) -> Tuple[List, List, Dict]:
+        """Get Table Schema details from Glue Catalog. Should only be called
+            when migration is True, i.e. Glue Catalog still has this table as Parquet
+            and will be migrated to ICEBERG."""
+        columns = tbl_dict['StorageDescriptor']['Columns']
+        partition_cols = tbl_dict['PartitionKeys']
+        all_columns: Dict[str, str] = columns + partition_cols
+        if all_columns:
+            # id column added to match the spec same as ICEBERG table.
+            column_details = [{"id": i, **d} for i, d in enumerate(all_columns, start=1)]
+            # only name and field-id is requried from this.
+            partition_details = [{"field-id": i, **d} for i, d in enumerate(partition_cols, start=1000)]
+            # TBLPROPERTIES dict doesn't matter as table is parquet currently.
+            return column_details, partition_details, {}
+        else:
+            raise Exception("No columns extracted from Glue Catalog.")
+
+    def _compare_schemas(self, catalog_details, hql_details):
+        print("Use pandas to get the changes here...")
+
+
+    #TODO: Compare Schema -- get the change details.
+    def get_schema_updates(self):
+        if self.catalog == "glue":
+            tbl_details = get_table_details(self._db, self._table)['Table']
+            if not self.migration:
+                metadata_path = self._get_metadata_location(tbl_details)
+                # c_ is to identify catalog columns, i.e. table details in catalog right now
+                c_columns, c_partition_cols, c_tblprop = self._get_schema_details_metadata(metadata_path)
+            else:
+                c_columns, c_partition_cols, c_tblprop = self._get_schema_details(tbl_details)
+
+    ## Comparison need to happen twice in case of migration = True
+    # TODO: :thinking: comparison should be done before and after of the comparison ?

--- a/src/utils/glue_utils.py
+++ b/src/utils/glue_utils.py
@@ -71,7 +71,7 @@ def update_table_schema(table, new_cols, del_cols):
     else:
         updated_columns = new_cols_list
 
-    logger.debug(f"Final cols list ==> {updated_columns}")
+    logger.debug("Final cols list ==> %s", updated_columns)
     updated_table["Table"]["StorageDescriptor"]["Columns"] = updated_columns
 
     up_response = glue_client.update_table(
@@ -80,10 +80,10 @@ def update_table_schema(table, new_cols, del_cols):
 
     # Check if the update is successful or not.
     if up_response["ResponseMetadata"]["HTTPStatusCode"] == 200:
-        logger.info(f"Update successful for {db_name}.{table_name}")
+        logger.info("Update successful for %s.%s", db_name, table_name)
         return True, f"{db_name}.{table_name}", None
     else:
-        logger.error(f"Update failure for {db_name}.{table_name}")
+        logger.error("Update failure for %s.%s", db_name, table_name)
         return False, f"{db_name}.{table_name}", up_response["Error"]
 
 
@@ -102,7 +102,7 @@ def get_latest_table_version(database, table):
             version_id = response['TableVersions'][0]['VersionId']
             return version_id
         else:
-            logger.critical(f"No version available for the {database}.{table}")
+            logger.critical("No version available for the %s.%s", database, table)
             raise Exception(f"No version available for the {database}.{table}")
     except ClientError as error:
         err_response = error.response

--- a/src/utils/helper.py
+++ b/src/utils/helper.py
@@ -18,13 +18,17 @@ def initial_checks(table_info):
     # RULES:
     # 1. TABLE_TYPE is EXTERNAL
     # 2. TABLE IS A PARQUET TABLE => check serde info
+    # Run all the initial rules before sending the response.
+    validation_results = {}
     for key, value in rbook.INITIAL_RULE_DICT.items():
         vresult = value(table_info)
         if not vresult:
             logger.error("%s validation failed.", key)
-            # TODO: MAYBE update this later to something more meaningful ? A failure event ?
-            return key, False
-    return "all", True
+            validation_results[key] = False
+        else:
+            validation_results[key] = True
+    logger.info("Validation results %s", validation_results)
+    return validation_results
 
 
 def compare_schema(new_col_list, old_col_list):

--- a/src/utils/helper.py
+++ b/src/utils/helper.py
@@ -21,7 +21,7 @@ def intial_checks(table_info):
     for key, value in rbook.INITIAL_RULE_DICT.items():
         vresult = value(table_info)
         if not vresult:
-            logger.error(f"{key} validation failed.")
+            logger.error("%s validation failed.", key)
             # TODO: MAYBE update this later to something more meaningful ? A failure event ?
             return key, False
     return "all", True
@@ -74,14 +74,14 @@ def compare_schema(new_col_list, old_col_list):
         ["Name", "Type"]
     ].to_dict("records")
 
-    logger.info(f"++++ Newly Added columns ==> {added_cols}")
-    logger.info(f"---- Deleted columns ===> {deleted_cols}")
-    logger.info(f"++++ New columns count ==> {len(added_cols)}")
-    logger.info(f"---- Deleted columns count ===> {len(deleted_cols)}")
+    logger.info("++++ Newly Added columns ==> %s", added_cols)
+    logger.info("---- Deleted columns ===> %s", deleted_cols)
+    logger.info("++++ New columns count ==> %d", len(added_cols))
+    logger.info("---- Deleted columns count ===> %d", len(deleted_cols))
 
     if not datatype_changes.empty:
-        logger.warn(
-            f'+-+- data type changes records for: {datatype_changes["Name"].to_list()}'
+        logger.warning(
+            '+-+- data type changes records for: %s', datatype_changes["Name"].to_list()
         )
     return added_cols, deleted_cols, datatype_changes
 

--- a/src/utils/helper.py
+++ b/src/utils/helper.py
@@ -9,7 +9,7 @@ from rules import rule_book as rbook
 logger = logging.getLogger('EA.utils.helper')
 
 
-def intial_checks(table_info):
+def initial_checks(table_info):
     """
     Runs the initial validation rules
     :param table_info: dict


### PR DESCRIPTION
- Refactored code from `process.py` to `alterator.py` for maintaining code easily.
- Added initial support to Identify Apache Iceberg Schema Changes.
- Added Table Type Identification, i.e. A table can be identified as `Parquet`, `Iceberg` and `non-parquet` tables.
- `non-parquet` tables currently are assumed as `TEXT` tables.

- Added support to identify in case the table format is changed, for e.g. Table in catalog is `PARQUET` but DDL for table is provided for `ICEBERG`, This is identified as format change from `PARQUET` to `ICEBERG`